### PR TITLE
Add an API to check whether a Discord Username is registered

### DIFF
--- a/RootLeagueProject/urls.py
+++ b/RootLeagueProject/urls.py
@@ -20,12 +20,14 @@ from django.contrib.sitemaps import views as sitemap_views
 from rest_framework import routers
 
 from matchmaking import views as match_views
+from authentification import views as authentification_views
 from misc import views as misc_views
 from .sitemaps import sitemaps
 
 # DRF rooter
 router = routers.SimpleRouter()
 router.register('match', match_views.MatchViewset, basename='match')
+router.register('registration', authentification_views.PlayerRegistrationViewSet, basename='registration')
 
 urlpatterns = [
     path("select2/", include("django_select2.urls")),

--- a/RootLeagueProject/urls.py
+++ b/RootLeagueProject/urls.py
@@ -27,6 +27,7 @@ from .sitemaps import sitemaps
 # DRF rooter
 router = routers.SimpleRouter()
 router.register('match', match_views.MatchViewset, basename='match')
+router.register('player', authentification_views.PlayerViewSet, basename='player')
 router.register('registration', authentification_views.PlayerRegistrationViewSet, basename='registration')
 
 urlpatterns = [

--- a/authentification/serializers.py
+++ b/authentification/serializers.py
@@ -1,0 +1,9 @@
+from rest_framework.serializers import ModelSerializer
+
+from .models import Player
+
+
+class PlayerRegistrationSerializer(ModelSerializer):
+    class Meta:
+        model = Player
+        fields = ["discord_name", "in_game_name", "in_game_id"]

--- a/authentification/serializers.py
+++ b/authentification/serializers.py
@@ -2,8 +2,7 @@ from rest_framework.serializers import ModelSerializer
 
 from .models import Player
 
-
-class PlayerRegistrationSerializer(ModelSerializer):
+class PlayerSerializer(ModelSerializer):
     class Meta:
         model = Player
-        fields = ["discord_name", "in_game_name", "in_game_id"]
+        fields = ["id", "discord_name", "in_game_name", "in_game_id"]

--- a/authentification/views.py
+++ b/authentification/views.py
@@ -6,7 +6,12 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from . import forms
+from rest_framework.mixins import RetrieveModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from . import forms, serializers
+from .models import Player
+
 
 # Create your views here.
 
@@ -65,3 +70,9 @@ class PlayerPasswordResetConfirmView(SuccessMessageMixin, PasswordResetConfirmVi
     success_message = _("Password changed successfully!")
     extra_context = {'upper_title' : _("Account"),
                      'lower_title' : _("Reset Password")}
+
+# API ViewSet for checking whether a particular Player, with the specified Discord Username, is registered for league
+class PlayerRegistrationViewSet(GenericViewSet, RetrieveModelMixin):
+    queryset = Player.objects.all()
+    serializer_class = serializers.PlayerRegistrationSerializer
+    lookup_field = "discord_name"

--- a/authentification/views.py
+++ b/authentification/views.py
@@ -6,11 +6,11 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
-from rest_framework.mixins import RetrieveModelMixin
-from rest_framework.viewsets import GenericViewSet
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from . import forms, serializers
+from . import forms
 from .models import Player
+from .serializers import PlayerSerializer
 
 
 # Create your views here.
@@ -70,9 +70,13 @@ class PlayerPasswordResetConfirmView(SuccessMessageMixin, PasswordResetConfirmVi
     success_message = _("Password changed successfully!")
     extra_context = {'upper_title' : _("Account"),
                      'lower_title' : _("Reset Password")}
+    
+class PlayerViewSet(ReadOnlyModelViewSet):
+    serializer_class = PlayerSerializer
+ 
+    def get_queryset(self):
+        return Player.objects.filter(is_active=True)
 
 # API ViewSet for checking whether a particular Player, with the specified Discord Username, is registered for league
-class PlayerRegistrationViewSet(GenericViewSet, RetrieveModelMixin):
-    queryset = Player.objects.all()
-    serializer_class = serializers.PlayerRegistrationSerializer
+class PlayerRegistrationViewSet(PlayerViewSet):
     lookup_field = "discord_name"


### PR DESCRIPTION
This change adds a new API on `/api/registration/{discord_name}` to check whether a particular Discord user is registered for league play.

If a player is found with the given Discord name, the API will return HTTP status code `200 OK` alongside the in-game name and ID of that player.

Otherwise, the API will  return HTTP status code `404 Not Found` alongside a detail message.

### Rationale

This API could be used by the Discord bot to check that all players are registered automatically when opening a new game's thread, and take appropriate action.